### PR TITLE
feat(createendpoint): allow to omit the input property

### DIFF
--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -78,9 +78,10 @@ function wrapWithRescueAndValidation<T extends Routing>(routing: T) {
         Object.entries(route).map(([method, endpoint]) => {
           const handlers = Array.isArray(endpoint.handlers) ? endpoint.handlers : [endpoint.handlers]
           const rescuedHandlers = handlers.map(rescue)
+          const finalHandlers = endpoint.input ? [validate(endpoint.input), ...rescuedHandlers] : rescuedHandlers
           const wrappedRouteDef = {
             ...endpoint,
-            handlers: [validate(endpoint.input), ...rescuedHandlers],
+            handlers: finalHandlers,
           }
           return [method, wrappedRouteDef]
         }),

--- a/usage/index.ts
+++ b/usage/index.ts
@@ -141,6 +141,18 @@ const dummy = createEndpoint({
   },
 })
 
+const noInput = createEndpoint({
+  description: 'This is a dummy endpoint with no input',
+  output: {
+    200: {
+      body: z.object({ ok: z.boolean() }),
+    },
+  },
+  handlers: (_req, res, _next) => {
+    res.status(200).json({ ok: true })
+  },
+})
+
 const routing: Routing = {
   '/users': {
     post: createUser,
@@ -150,6 +162,9 @@ const routing: Routing = {
   },
   '/dummy': {
     post: dummy,
+  },
+  '/no-input': {
+    post: noInput,
   },
 }
 


### PR DESCRIPTION
In cases when there's no input, like on GET requests, you can omit the input object and the OAS will not render it