### PR TITLE
Add local and global error handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
   type ResponseMap,
   type ResponseDefinition,
 } from './lib/create-endpoint'
-export { createApi, type Route, type HttpMethod } from './lib/create-api'
+export { type Route, type HttpMethod } from './lib/create-api'
 export { createApp, type OpenApiInfo, type CreateAppParams, type Routing } from './lib/create-app'
 
 // Extend Zod with OpenAPI support

--- a/src/lib/create-api.ts
+++ b/src/lib/create-api.ts
@@ -1,11 +1,20 @@
 import { type Endpoint } from './create-endpoint'
 
+/**
+ * Supported HTTP methods
+ */
 export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options' | 'trace'
 
+/**
+ * Route definition
+ */
 export type Route = {
   [k in HttpMethod]?: Endpoint<any, any, any, any>
 }
 
+/**
+ * Flattened routing object, where the key is the path and the value is the route
+ */
 export type FlatRouting = Record<string, Route>
 
 /**

--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -1,4 +1,4 @@
-import express, { type Express } from 'express'
+import express, { type ErrorRequestHandler, type Express } from 'express'
 import fs from 'node:fs'
 import {
   OpenApiBuilder,
@@ -13,10 +13,10 @@ import {
 import swaggerUi from 'swagger-ui-express'
 import yaml from 'yaml'
 import { createApi, type FlatRouting, type HttpMethod, type Route } from './create-api'
+import { type ErrorHandler, type Handler } from './create-endpoint'
 import { defaultErrorHandler } from './error-handler'
 import { rescue } from './rescue'
 import { validate } from './validate'
-import { type ErrorHandler, type Handler } from './create-endpoint'
 
 /**
  * OpenAPI definitions for the API object.
@@ -92,7 +92,7 @@ export interface CreateAppParams {
   openApiInfo: OpenApiInfo
   routing: Routing
   app?: Express
-  errorHandler?: ErrorHandler
+  errorHandler?: ErrorRequestHandler
   documentation?:
     | Partial<{
         ui: UIOptions

--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -13,7 +13,7 @@ import {
 import swaggerUi from 'swagger-ui-express'
 import yaml from 'yaml'
 import { createApi, type FlatRouting, type HttpMethod, type Route } from './create-api'
-import { errorHandler } from './error-handler'
+import { defaultErrorHandler } from './error-handler'
 import { rescue } from './rescue'
 import { validate } from './validate'
 import { type ErrorHandler, type Handler } from './create-endpoint'
@@ -80,10 +80,19 @@ interface FSOptions {
  */
 export type Routing = FlatRouting | Record<string, FlatRouting | Route>
 
+/**
+ * Params for creating the api
+ * @param openApiInfo OpenAPI specification params
+ * @param routing Route definitions
+ * @param [app] Optional express app to use, if not passed a new express app will be created
+ * @param [errorHandler] Optional error handler to use, if not passed the default error handler will be used
+ * @param [documentation] Optional documentation options
+ */
 export interface CreateAppParams {
   openApiInfo: OpenApiInfo
   routing: Routing
   app?: Express
+  errorHandler?: ErrorHandler
   documentation?:
     | Partial<{
         ui: UIOptions
@@ -170,7 +179,7 @@ function createExpressApp() {
  * @returns Express app
  */
 export function createApp(config: CreateAppParams) {
-  const { openApiInfo, routing, app = createExpressApp(), documentation } = config
+  const { openApiInfo, routing, app = createExpressApp(), documentation, errorHandler = defaultErrorHandler } = config
 
   const wrappedRoutes: FlatRouting = wrapWithRescueAndValidation(routing)
 

--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -18,6 +18,9 @@ import { errorHandler } from './error-handler'
 import { rescue } from './rescue'
 import { validate } from './validate'
 
+/**
+ * OpenAPI definitions for the API object.
+ */
 export interface OpenApiInfo {
   info: InfoObject
   servers?: ServerObject[]
@@ -37,6 +40,44 @@ interface FSOptions {
   format: 'json' | 'yaml'
 }
 
+/**
+ * Routing is a tree-like structure that defines the API routes.
+ * It can be flat or nested. Which means you can have a single route definition
+ * using the path as the key and the route definition as the value
+ * or you can nest routes by using an object where the key is the prefix
+ * and the value is another routing object with the path as the key and the route
+ * as the value
+ *
+ * This structure only supports a single level of nesting.
+ *
+ * @example
+ * ```ts
+ * const routing = {
+ *   '/ping': {
+ *     get: {
+ *       handlers: [],
+ *       output: {
+ *         200: {
+ *           body: <your schema here>,
+ *         },
+ *       },
+ *     },
+ *   },
+ *   '/users': {
+ *     '/me': {
+ *       get: {
+ *         handlers: [],
+ *         output: {
+ *           200: {
+ *             body: <your schema here>,
+ *           },
+ *         },
+ *       },
+ *     },
+ *   },
+ * }
+ * ```
+ */
 export type Routing = FlatRouting | Record<string, FlatRouting | Route>
 
 export interface CreateAppParams {

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -1,7 +1,7 @@
 import { type NextFunction, type Request, type Response } from 'express'
 import { ZodError } from 'zod'
 
-export const errorHandler = (err: any, _req: Request, res: Response, next: NextFunction) => {
+export const defaultErrorHandler = (err: any, _req: Request, res: Response, next: NextFunction) => {
   if (err instanceof ZodError) {
     return res.status(422).json({
       message: 'Validation error. See `details` property',

--- a/test/create-app.test.ts
+++ b/test/create-app.test.ts
@@ -1,7 +1,10 @@
+import assert from 'node:assert'
 import { describe, it, mock } from 'node:test'
+import Sinon from 'sinon'
 import { Routing, z } from '../src'
-import { flattenRoutes, wrapWithRescueAndValidation } from '../src/lib/create-app'
-import { deepStrictEqual, strictEqual } from 'node:assert'
+import express from 'express'
+import { createApp, flattenRoutes, wrapWithRescueAndValidation } from '../src/lib/create-app'
+import { defaultErrorHandler } from '../src/lib/error-handler'
 
 describe('create-app', () => {
   const noop = mock.fn()
@@ -24,7 +27,7 @@ describe('create-app', () => {
         },
       }
       const result = flattenRoutes(routes)
-      deepStrictEqual(result, {
+      assert.deepStrictEqual(result, {
         '/users/me': {
           get: {
             handlers: [noop],
@@ -71,8 +74,8 @@ describe('create-app', () => {
         },
       }
       const result = wrapWithRescueAndValidation(routes)
-      strictEqual(result['/users']['post'].handlers.length, 2)
-      strictEqual(result['/ping']['get'].handlers.length, 1)
+      assert.strictEqual(result['/users']['post'].handlers.length, 2)
+      assert.strictEqual(result['/ping']['get'].handlers.length, 1)
     })
 
     it('should handle nested routes', () => {
@@ -106,8 +109,82 @@ describe('create-app', () => {
         },
       }
       const result = wrapWithRescueAndValidation(routes)
-      strictEqual(result['/users/me']['post'].handlers.length, 2)
-      strictEqual(result['/ping']['get'].handlers.length, 1)
+      assert.strictEqual(result['/users/me']['post'].handlers.length, 2)
+      assert.strictEqual(result['/ping']['get'].handlers.length, 1)
+    })
+  })
+
+  describe('global errorHandler overrides', () => {
+    it('should allow the user to override the default error handler', () => {
+      const routes: Routing = {
+        '/ping': {
+          get: {
+            handlers: [noop],
+            output: {
+              200: {
+                body: {
+                  foo: z.string(),
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const useSpy = Sinon.spy()
+      const mockHandler = Sinon.spy()
+      const app = express()
+      app.use = useSpy
+
+      createApp({
+        app,
+        openApiInfo: {
+          info: {
+            title: 'Test',
+            version: '1.0.0',
+          },
+        },
+        routing: routes,
+        errorHandler: mockHandler,
+      })
+
+      assert.strictEqual(useSpy.callCount, 1)
+      assert.strictEqual(useSpy.firstCall.args[0], mockHandler)
+    })
+
+    it('should use the default error handler if not set up', () => {
+      const routes: Routing = {
+        '/ping': {
+          get: {
+            handlers: [noop],
+            output: {
+              200: {
+                body: {
+                  foo: z.string(),
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const useSpy = Sinon.spy()
+      const app = express()
+      app.use = useSpy
+
+      createApp({
+        app,
+        openApiInfo: {
+          info: {
+            title: 'Test',
+            version: '1.0.0',
+          },
+        },
+        routing: routes,
+      })
+
+      assert.strictEqual(useSpy.callCount, 1)
+      assert.strictEqual(useSpy.firstCall.args[0], defaultErrorHandler)
     })
   })
 })


### PR DESCRIPTION
- **docs(create-api): add internal docs to interfaces**
- **fix(index): remove exported 'createApi' function**
- **docs(create-app): add internal docs**
- **feat(error-handler): add erorr handlers for specific routes**
- **feat(error-handler): add global property for error handlers**
- **fix(create-app): fix global error handler type**
- **test(create-app/error-handlers): add tests to global and local error handlers**
