### PR TITLE
fix(output): don't allow empty outputs

### DIFF
--- a/src/lib/create-endpoint.ts
+++ b/src/lib/create-endpoint.ts
@@ -7,7 +7,7 @@ import {
   type ResponseObject,
 } from 'openapi3-ts/oas31'
 import { type ZodObject, type ZodTypeAny, type z } from 'zod'
-import { type OneOrMore, type ValueOf } from '../types'
+import { type NonEmptyObj, type OneOrMore, type ValueOf } from '../types'
 
 export interface ResponseDefinition {
   body: ZodTypeAny
@@ -52,7 +52,7 @@ export type Endpoint<
   handlers: EndpointParams<RequestBody, Params, Query, ResponseBodies>['handlers']
   errorHandler?: EndpointParams<RequestBody, Params, Query, ResponseBodies>['errorHandler']
   input?: EndpointParams<RequestBody, Params, Query, ResponseBodies>['input']
-  output: ResponseBodies
+  output: EndpointParams<RequestBody, Params, Query, ResponseBodies>['output']
 }
 
 /**
@@ -77,7 +77,7 @@ export type EndpointParams<
     query?: ZodObject<any, 'strip', ZodTypeAny, Query, any>
     headers?: HeadersObject
   }
-  output: ResponseBodies
+  output: NonEmptyObj<ResponseBodies, 'Output cannot be empty'>
   handlers: OneOrMore<Handler<RequestBody, Params, Query, ResponseBodies>>
   errorHandler?: ErrorHandler<RequestBody, Params, Query, ResponseBodies>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,4 @@
 export type OneOrMore<T> = T | [T, ...T[]]
 export type ValueOf<T> = T[keyof T]
+export type NonEmptyObj<T extends Record<string, unknown>, Message extends string = 'Object cannot be empty'> =
+  T extends Record<string, never> ? Message : T

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -126,7 +126,11 @@ describe('create-app', () => {
                 throw new Error()
               },
             ],
-            output: {},
+            output: {
+              200: {
+                body: z.any(),
+              },
+            },
           }),
         },
       },
@@ -349,7 +353,11 @@ describe('create-app', () => {
                   throw new Error('Error from get')
                 },
               ],
-              output: {},
+              output: {
+                200: {
+                  body: z.any(),
+                },
+              },
             }),
             post: createEndpoint({
               handlers: [
@@ -357,7 +365,11 @@ describe('create-app', () => {
                   throw new Error('Error from post')
                 },
               ],
-              output: {},
+              output: {
+                200: {
+                  body: z.any(),
+                },
+              },
             }),
           },
         },


### PR DESCRIPTION
Outputs will always have at least one response, requests cannot respond to nothing so now outputs do
not allow empty responses

BREAKING CHANGE: Any empty outputs will now fail type check. Any endpoints MUST now have at least
one key in the output object